### PR TITLE
Implement wikipedia lookup tool

### DIFF
--- a/tools/wikipedia_lookup_tool.py
+++ b/tools/wikipedia_lookup_tool.py
@@ -1,0 +1,20 @@
+import requests
+
+
+def wikipedia_lookup(query: str) -> str:
+    """Return the summary for the given Wikipedia query."""
+    try:
+        lowered = query.lower()
+        if "infobox" in lowered or "table" in lowered:
+            return "Structured infobox/table parsing not implemented in this version."
+
+        api_url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{query}"
+        resp = requests.get(api_url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        summary = data.get("extract", "").strip()
+        if not summary:
+            return "No summary found."
+        return summary
+    except Exception as e:
+        return f"Tool error: {e}"


### PR DESCRIPTION
## Summary
- add `wikipedia_lookup_tool.py`
- return a message when a query tries to access structured data
- fetch summary from Wikipedia REST API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ded6e1324832fb890e82bc9087061