### PR TITLE
Add Wikipedia tool to GAIAAgent

### DIFF
--- a/agents/gaia_agent.py
+++ b/agents/gaia_agent.py
@@ -1,5 +1,6 @@
 from tools.reverse_string_tool import reverse_string
 from tools.filter_vegetables_tool import filter_vegetables
+from tools.wikipedia_lookup_tool import lookup_wikipedia
 
 class GAIAAgent:
     def __init__(self):
@@ -16,6 +17,17 @@ class GAIAAgent:
         if "vegetable" in lower_q or "veggie" in lower_q:
             print("GAIAAgent using filter_vegetables tool.")
             return filter_vegetables(question)
+
+        wiki_keywords = [
+            "wikipedia",
+            "nominated",
+            "studio albums",
+            "first name",
+            "featured article",
+        ]
+        if any(keyword in lower_q for keyword in wiki_keywords):
+            print("GAIAAgent using lookup_wikipedia tool.")
+            return lookup_wikipedia(question)
         fixed_answer = "This is a default answer."
         print(f"Agent returning fixed answer: {fixed_answer}")
         return fixed_answer


### PR DESCRIPTION
## Summary
- integrate `lookup_wikipedia` tool into `GAIAAgent`
- select Wikipedia tool when keywords such as "nominated" or "studio albums" appear
- maintain existing logic for reverse and vegetable tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516b353284832f8a13986c982e1b15